### PR TITLE
Reduce memory usage of S2K iteration

### DIFF
--- a/src/Common/GenericS2K.php
+++ b/src/Common/GenericS2K.php
@@ -166,8 +166,7 @@ class GenericS2K implements S2KInterface
         if (strlen($data) >= $this->count) {
             return $data;
         }
-        $data = str_repeat($data, (int) ceil($this->count / strlen($data)));
-        return substr($data, 0, $this->count);
+        return str_repeat($data, (int) ceil($this->count / strlen($data))) . substr($data, 0, $this->count % strlen($data));
     }
 
     private function hash(string $data, int $size): string

--- a/src/Common/GenericS2K.php
+++ b/src/Common/GenericS2K.php
@@ -166,7 +166,7 @@ class GenericS2K implements S2KInterface
         if (strlen($data) >= $this->count) {
             return $data;
         }
-        return str_repeat($data, (int) ceil($this->count / strlen($data))) . substr($data, 0, $this->count % strlen($data));
+        return str_repeat($data, (int) floor($this->count / strlen($data))) . substr($data, 0, $this->count % strlen($data));
     }
 
     private function hash(string $data, int $size): string


### PR DESCRIPTION
With very large S2K count values, creating the key object was using double the memory of the S2K value because it first built a longer-than-needed string and then used substr to get only the needed length, which created another new string object.

This PR replaces str_repeat(..., ceil(...)) (making a too-long string) and substr (trimming it) with str_repeat(..., floor(...)) (making a too-short string) and a different use of substr (padding it with the remainder).

fixes #9